### PR TITLE
Add python extension Fix #12

### DIFF
--- a/__test__/services/model.service.spec.js
+++ b/__test__/services/model.service.spec.js
@@ -36,4 +36,5 @@ describe('Test all methods from Model Service', () => {
 afterAll(() => {
     fs.unlinkSync(path.join(__dirname, '..', '..', 'output-models', 'Province.ts'))
     fs.unlinkSync(path.join(__dirname, '..', '..', 'output-models', 'Province.js'))
+    fs.unlinkSync(path.join(__dirname, '..', '..', 'output-models', 'Province.py'))
 })

--- a/__test__/services/model.service.spec.js
+++ b/__test__/services/model.service.spec.js
@@ -21,6 +21,11 @@ describe('Test all methods from Model Service', () => {
         expect(fs.existsSync(path.join(__dirname, '..', '..', 'output-models', 'Province.ts')))
             .toBe(true)
     })
+    test('Should create the .py class for the provided model', async () => {
+        ModelService.exportModel({ model: 'Province', extension: 'py' }, dbPath)
+        expect(fs.existsSync(path.join(__dirname, '..', '..', 'output-models', 'Province.py')))
+            .toBe(true)
+    })
     test('Should create the .js class for the provided model', async () => {
         ModelService.exportModel({ model: 'Province', extension: 'js' }, dbPath)
         expect(fs.existsSync(path.join(__dirname, '..', '..', 'output-models', 'Province.js')))

--- a/lib/services/model.service.js
+++ b/lib/services/model.service.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const { INVALID_MODEL_ERROR } = require('../constants/messages.constants');
 const { buildTypeScript } = require('./types/typescript.service');
 const { buildJavaScript } = require('./types/javascript.service');
+const { buildPython } = require('./types/python.service');
 const defaults = {
     basePath: path.resolve('./'),
     exportFolder: '/output-models'
@@ -25,6 +26,9 @@ function exportModel(argv, sequelizePath) {
     switch (extension) {
         case 'js':
             jsonString = buildJavaScript(model, modelname)
+            break;
+        case 'py':
+            jsonString = buildPython(model, modelname)
             break;
         default:
             jsonString = buildTypeScript(model, modelname)

--- a/lib/services/types/python.service.js
+++ b/lib/services/types/python.service.js
@@ -43,21 +43,21 @@ function getPyClass(modelname, schema, associations, imports) {
     let constructorArgs = []
     for (const [key, value] of Object.entries(snakeize(schema))) {
         const arg = `${key}: ${value}`
-        classString += `    ${arg}\n`
+        classString += `\t${arg}\n`
         constructorArgs.push(arg)
     }
     for (const [key, value] of Object.entries(snakeize(associations))) {
         const arg = `${key}: ${value}`
-        classString += `    ${arg}\n`
+        classString += `\t${arg}\n`
         constructorArgs.push(arg)
     }
     classString += '\n'
-    classString += `    def __init__(self, ${constructorArgs.join(', ')}):\n`
+    classString += `\tdef __init__(self, ${constructorArgs.join(', ')}):\n`
     for (const key in snakeize(schema)) {
-        classString += `        self.${key} = ${key}\n`
+        classString += `\t\tself.${key} = ${key}\n`
     }
     for (const key in snakeize(associations)) {
-        classString += `        self.${key} = ${key}\n`
+        classString += `\t\tself.${key} = ${key}\n`
     }
     return classString
 }

--- a/lib/services/types/python.service.js
+++ b/lib/services/types/python.service.js
@@ -1,0 +1,89 @@
+const { mapValues } = require('lodash')
+const { snakeize } = require('casing')
+
+/**
+ * Create a string of a Python class
+ * @param {*} model the sequelize model
+ * @param {*} modelname the name of the model 
+ * @returns the class to write in the file
+ */
+function buildPython(model, modelname) {
+    let useSequenceImport = false;
+    let useDatetimeImport = false;
+    let fields = mapValues(model.rawAttributes, item => {
+        const itemType = item.type.constructor.name
+        if (['DATE', 'DATEONLY'].includes(itemType)) 
+            useDatetimeImport = true;
+        return getPyDataType(itemType)
+    })
+    let associations = mapValues(model.associations, item => {
+        if (item.isMultiAssociation) {
+            useSequenceImport = true;
+            return `Sequence[${item.target.name}]`
+        }
+        return item.as
+    })
+    return getPyClass(modelname, fields, associations, { useDatetimeImport, useSequenceImport})
+}
+
+/**
+* Builds the Python class to write in the file
+* @param {*} modelname the name of the model to be use as the class name
+* @param {*} schema the field names and types
+* @param {*} associations the relations of the model
+* @returns the class in string format
+*/
+function getPyClass(modelname, schema, associations, imports) {
+    let classString = '# This class was exported via node package model-to-file.\n'
+    if (imports.useSequenceImport) classString += 'from typing import Sequence\n'
+    if (imports.useDatetimeImport) classString += `from datetime import datetime\n`
+    classString += '\n'
+    classString += `class ${modelname}:\n`
+    classString += '\n'
+    let constructorArgs = []
+    for (const [key, value] of Object.entries(snakeize(schema))) {
+        const arg = `${key}: ${value}`
+        classString += `    ${arg}\n`
+        constructorArgs.push(arg)
+    }
+    for (const [key, value] of Object.entries(snakeize(associations))) {
+        const arg = `${key}: ${value}`
+        classString += `    ${arg}\n`
+        constructorArgs.push(arg)
+    }
+    classString += '\n'
+    classString += `    def __init__(self, ${constructorArgs.join(', ')}):\n`
+    for (const key in snakeize(schema)) {
+        classString += `        self.${key} = ${key}\n`
+    }
+    for (const key in snakeize(associations)) {
+        classString += `        self.${key} = ${key}\n`
+    }
+    return classString
+}
+
+/**
+ * Returns the equivalent data types from Sequelize types to Python types
+ * @param {*} type sequelize field's type 
+ * @returns the equivalent Python type
+ */
+function getPyDataType(type) {
+    switch (type) {
+        case 'INTEGER':
+            return 'int';
+        case 'DECIMAL':
+        case 'DOUBLE':
+        case 'FLOAT':
+            return 'float'
+        case 'DATE':
+        case 'DATEONLY':
+            return 'datetime'
+        case 'BOOLEAN':
+            return 'bool'
+        case 'STRING':
+        case 'TEXT':
+            return 'str'
+    }
+}
+
+module.exports = { buildPython: buildPython }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "casing": "^1.1.0",
         "lodash": "^4.17.21",
         "minimist": "^1.2.6"
       },
@@ -1597,6 +1598,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001441",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
@@ -1612,6 +1621,15 @@
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
       ]
+    },
+    "node_modules/casing": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/casing/-/casing-1.1.0.tgz",
+      "integrity": "sha512-ReZ7abAmay4yxoU+MzRUaExGKIVCTaRTbKvfD21E4FJFOvnT+Kjtg+rcYWRaR/SM4dW/xdrJ+K2kZXj0wxsIfg==",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "snakeize": "^0.1.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4194,6 +4212,11 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/snakeize": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
+      "integrity": "sha512-ot3bb6pQt6IVq5G/JQ640ceSYTPtriVrwNyfoUw1LmQQGzPMAGxE5F+ded2UwSUCyf2PW1fFAYUnVEX21PWbpQ=="
+    },
     "node_modules/socks": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -6005,11 +6028,25 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
+    },
     "caniuse-lite": {
       "version": "1.0.30001441",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
       "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
       "dev": true
+    },
+    "casing": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/casing/-/casing-1.1.0.tgz",
+      "integrity": "sha512-ReZ7abAmay4yxoU+MzRUaExGKIVCTaRTbKvfD21E4FJFOvnT+Kjtg+rcYWRaR/SM4dW/xdrJ+K2kZXj0wxsIfg==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "snakeize": "^0.1.0"
+      }
     },
     "chalk": {
       "version": "4.1.2",
@@ -7951,6 +7988,11 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "optional": true
+    },
+    "snakeize": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
+      "integrity": "sha512-ot3bb6pQt6IVq5G/JQ640ceSYTPtriVrwNyfoUw1LmQQGzPMAGxE5F+ded2UwSUCyf2PW1fFAYUnVEX21PWbpQ=="
     },
     "socks": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "homepage": "https://github.com/orozco92/model-to-file#readme",
   "dependencies": {
+    "casing": "^1.1.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.6"
   },


### PR DESCRIPTION
### Description

Adds python extension for exporting models to Python classes. Closes #12. 

### Typing

Python has no explicit typing declaration (though it is a strongly typed language), type hinting is used instead for the base types as the following example:

```python
from typing import Sequence
from datetime import datetime

class Foo:
    
    name: str
    age: int
    birthday: datetime
    salary: float
    toolset: Sequence[Tool]
    active: bool
```

### New Dependencies

Variable and function name casing is converted from _camelCase_ to _snake_case_ as to comply with [PEP 8](https://peps.python.org/pep-0008/), using the [casing](https://www.npmjs.com/package/casing) package.