### PR TITLE
Add usage guide. Fixes #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ class Province {
 | Option               | Alias             | Description                                                         |
 | -------------------- | ----------------- | ------------------------------------------------------------------- |
 | model                | m                 | The name of the model you want to export                                 |
-| extension (optional) | e                 | File/language extension for the output class file. Defaults to `.ts`. Supports `ts`, `js`, `py` and `cs`. |
+| extension (optional) | e                 | File/language extension for the output class file. Defaults to `.ts`. Supports `ts`, `js`, `py`, `php` and `cs`. |
 | path (optional)      | p, sequelize-path | Path to the [Sequelize](https://sequelize.org) index.js file. By default `./models/index.js` |
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ class Province {
 
 ## Options
 
-| Option               | Alias             | Description                                                         |
-| -------------------- | ----------------- | ------------------------------------------------------------------- |
-| model                | m                 | The name of the model you want to export                                 |
+| Option               | Alias             | Description                                                                                                      |
+| -------------------- | ----------------- | -----------------------------------------------------------------------------------------------------------------|
+| model                | m                 | The name of the model you want to export.                                                                        |
 | extension (optional) | e                 | File/language extension for the output class file. Defaults to `.ts`. Supports `ts`, `js`, `py`, `php` and `cs`. |
-| path (optional)      | p, sequelize-path | Path to the [Sequelize](https://sequelize.org) index.js file. By default `./models/index.js` |
+| path (optional)      | p, sequelize-path | Path to the [Sequelize](https://sequelize.org) index.js file. By default `./models/index.js`.                    |
+| help (optional)      | h, help           | Display the usage guide.                                                                                         |
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # model-to-file
 
-Exports sequelize models to javascript/typescript class file
+Exports [Sequelize](https://sequelize.org) models from JavaScript to other high level programming language class files such as TypeScript and Python.
 
 ## Example
 
-```
-$ model-to-file --model Province --extension ts
+```bash
+model-to-file --model Province --extension ts
 ```
 
-will output Province.ts file
+will output `Province.ts` file
 
-```
+```ts
 class Province {
     id: number;
     name: string;
@@ -27,14 +27,14 @@ class Province {
 
 | Option               | Alias             | Description                                                         |
 | -------------------- | ----------------- | ------------------------------------------------------------------- |
-| model                | m                 | The model's name you want to export                                 |
-| extension (optional) | e                 | File extension to save. Default `.ts`. Supported extension (`ts`, `js`) |
-| path (optional)      | p, sequelize-path | Path to the index.js sequelize file. By default `./models/index.js` |
+| model                | m                 | The name of the model you want to export                                 |
+| extension (optional) | e                 | File/language extension for the output class file. Defaults to `.ts`. Supports `ts`, `js`, `py` and `cs`. |
+| path (optional)      | p, sequelize-path | Path to the [Sequelize](https://sequelize.org) index.js file. By default `./models/index.js` |
 
 ## Install
 
 Install it as a global package
 
-```
+```bash
 npm install model-to-file -g
 ```

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,11 +1,15 @@
-const { ModelService, SequelizeService } = require("./services");
+const { ModelService, SequelizeService, HelpService } = require("./services");
 const { alias } = require("./constants/utils.constants");
 
 module.exports = function () {
   const argv = require("minimist")(process.argv.slice(2), { alias });
   try {
-    let sequelizePath = SequelizeService.getSequelizePath(argv);
-    ModelService.exportModel(argv, sequelizePath);
+    if (argv.hasOwnProperty('h') || argv.hasOwnProperty('help')) {
+      HelpService.showUsageGuide();
+    } else {
+      let sequelizePath = SequelizeService.getSequelizePath(argv);
+      ModelService.exportModel(argv, sequelizePath);
+    }
   } catch (error) {
     console.error(error.message);
     process.exit(1);

--- a/lib/services/help.service.js
+++ b/lib/services/help.service.js
@@ -7,6 +7,13 @@ function showUsageGuide() {
             content: "Exports {bold Sequelize} JavaScript models to different high level programming language' class files.",
         },
         {
+            header: 'Synopsis',
+            content: [
+                '$ model-to-file {bold --model} ModelName [{bold -p}] {underline ./path/to/models/index.js} [{bold -e}] py',
+                '$ model-to-file {bold --help}'
+            ]
+        },
+        {
             header: 'Mandatory Options',
             optionList: [
                 {
@@ -26,16 +33,16 @@ function showUsageGuide() {
                     alias: 'e',
                     type: String,
                     typeLabel: '{underline ts}',
-                    description: 'File/language extension for the output class file.',
                     defaultOption: 'ts',
+                    description: 'File/language extension for the output class file. Supports {italic ts}, {italic js}, {italic py}, {italic php} and {italic cs}.',
                 },
                 {
                     name: 'path',
                     alias: 'p',
                     type: String,
                     typeLabel: '{underline ./models/index.js}',
-                    description: 'Path to the {bold Sequelize} index.js file.',
                     defaultOption: './models/index.js',
+                    description: 'Path to the {bold Sequelize} index.js file.',
                 },
                 {
                     name: 'help',

--- a/lib/services/help.service.js
+++ b/lib/services/help.service.js
@@ -1,0 +1,56 @@
+const cliUsage = require('command-line-usage');
+
+function showUsageGuide() {
+    const sections = [
+        {
+            header: 'model-to-file CLI Script',
+            content: "Exports {bold Sequelize} JavaScript models to different high level programming language' class files.",
+        },
+        {
+            header: 'Mandatory Options',
+            optionList: [
+                {
+                    name: 'model',
+                    alias: 'm',
+                    type: String,
+                    typeLabel: '{underline ModelName}',
+                    description: 'The name of the model you want to export.',
+                },
+            ],
+        },
+        {
+            header: 'Optional Arguments',
+            optionList: [
+                {
+                    name: 'extension',
+                    alias: 'e',
+                    type: String,
+                    typeLabel: '{underline ts}',
+                    description: 'File/language extension for the output class file.',
+                    defaultOption: 'ts',
+                },
+                {
+                    name: 'path',
+                    alias: 'p',
+                    type: String,
+                    typeLabel: '{underline ./models/index.js}',
+                    description: 'Path to the {bold Sequelize} index.js file.',
+                    defaultOption: './models/index.js',
+                },
+                {
+                    name: 'help',
+                    alias: 'h',
+                    type: Boolean,
+                    description: 'Print this usage guide.',
+                }
+            ],
+        },
+    ];
+
+    const usage = cliUsage(sections);
+    console.info(usage);
+}
+
+module.exports = {
+    showUsageGuide
+}

--- a/lib/services/index.js
+++ b/lib/services/index.js
@@ -1,6 +1,7 @@
 const ModelService = require('./model.service')
 const SequelizeService = require('./sequelize.service')
+const HelpService = require('./help.service')
 
 module.exports = {
-    ModelService, SequelizeService
+    ModelService, SequelizeService, HelpService
 }

--- a/lib/services/types/python.service.js
+++ b/lib/services/types/python.service.js
@@ -1,5 +1,4 @@
-const { mapValues } = require('lodash')
-const { snakeize } = require('casing')
+const { mapValues, snakeCase } = require('lodash')
 
 /**
  * Create a string of a Python class
@@ -41,23 +40,23 @@ function getPyClass(modelname, schema, associations, imports) {
     classString += `class ${modelname}:\n`
     classString += '\n'
     let constructorArgs = []
-    for (const [key, value] of Object.entries(snakeize(schema))) {
-        const arg = `${key}: ${value}`
+    for (const [key, value] of Object.entries(schema)) {
+        const arg = `${snakeCase(key)}: ${value}`
         classString += `\t${arg}\n`
         constructorArgs.push(arg)
     }
-    for (const [key, value] of Object.entries(snakeize(associations))) {
-        const arg = `${key}: ${value}`
+    for (const [key, value] of Object.entries(associations)) {
+        const arg = `${snakeCase(key)}: ${value}`
         classString += `\t${arg}\n`
         constructorArgs.push(arg)
     }
     classString += '\n'
     classString += `\tdef __init__(self, ${constructorArgs.join(', ')}):\n`
-    for (const key in snakeize(schema)) {
-        classString += `\t\tself.${key} = ${key}\n`
+    for (const key in schema) {
+        classString += `\t\tself.${snakeCase(key)} = ${snakeCase(key)}\n`
     }
-    for (const key in snakeize(associations)) {
-        classString += `\t\tself.${key} = ${key}\n`
+    for (const key in associations) {
+        classString += `\t\tself.${snakeCase(key)} = ${snakeCase(key)}\n`
     }
     return classString
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "casing": "^1.1.0",
+        "command-line-usage": "^6.1.3",
         "lodash": "^4.17.21",
         "minimist": "^1.2.6"
       },
@@ -1368,6 +1369,14 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.3.1.tgz",
@@ -1747,6 +1756,84 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/command-line-usage": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
+      "dependencies": {
+        "array-back": "^4.0.2",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.2",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1801,6 +1888,14 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -3926,6 +4021,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4422,6 +4525,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/tar": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
@@ -4529,6 +4646,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/unique-filename": {
@@ -4677,6 +4802,18 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "dependencies": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -5848,6 +5985,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+    },
     "babel-jest": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.3.1.tgz",
@@ -6133,6 +6275,68 @@
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true
     },
+    "command-line-usage": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
+      "requires": {
+        "array-back": "^4.0.2",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.2",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6176,6 +6380,11 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -7808,6 +8017,11 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8142,6 +8356,17 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      }
+    },
     "tar": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
@@ -8228,6 +8453,11 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
+    },
+    "typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
     },
     "unique-filename": {
       "version": "1.1.1",
@@ -8346,6 +8576,15 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "requires": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
       }
     },
     "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "casing": "^1.1.0",
         "command-line-usage": "^6.1.3",
         "lodash": "^4.17.21",
         "minimist": "^1.2.6"
@@ -1607,14 +1606,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001441",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
@@ -1630,15 +1621,6 @@
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
       ]
-    },
-    "node_modules/casing": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/casing/-/casing-1.1.0.tgz",
-      "integrity": "sha512-ReZ7abAmay4yxoU+MzRUaExGKIVCTaRTbKvfD21E4FJFOvnT+Kjtg+rcYWRaR/SM4dW/xdrJ+K2kZXj0wxsIfg==",
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "snakeize": "^0.1.0"
-      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4315,11 +4297,6 @@
         "npm": ">= 3.0.0"
       }
     },
-    "node_modules/snakeize": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
-      "integrity": "sha512-ot3bb6pQt6IVq5G/JQ640ceSYTPtriVrwNyfoUw1LmQQGzPMAGxE5F+ded2UwSUCyf2PW1fFAYUnVEX21PWbpQ=="
-    },
     "node_modules/socks": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -6170,25 +6147,11 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
-    "camelize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
-    },
     "caniuse-lite": {
       "version": "1.0.30001441",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
       "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
       "dev": true
-    },
-    "casing": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/casing/-/casing-1.1.0.tgz",
-      "integrity": "sha512-ReZ7abAmay4yxoU+MzRUaExGKIVCTaRTbKvfD21E4FJFOvnT+Kjtg+rcYWRaR/SM4dW/xdrJ+K2kZXj0wxsIfg==",
-      "requires": {
-        "camelize": "^1.0.0",
-        "snakeize": "^0.1.0"
-      }
     },
     "chalk": {
       "version": "4.1.2",
@@ -8202,11 +8165,6 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "optional": true
-    },
-    "snakeize": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
-      "integrity": "sha512-ot3bb6pQt6IVq5G/JQ640ceSYTPtriVrwNyfoUw1LmQQGzPMAGxE5F+ded2UwSUCyf2PW1fFAYUnVEX21PWbpQ=="
     },
     "socks": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "homepage": "https://github.com/orozco92/model-to-file#readme",
   "dependencies": {
-    "casing": "^1.1.0",
     "command-line-usage": "^6.1.3",
     "lodash": "^4.17.21",
     "minimist": "^1.2.6"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "homepage": "https://github.com/orozco92/model-to-file#readme",
   "dependencies": {
     "casing": "^1.1.0",
+    "command-line-usage": "^6.1.3",
     "lodash": "^4.17.21",
     "minimist": "^1.2.6"
   },


### PR DESCRIPTION
### Description

Adds usage guide via `-h`, `--help` CLI options. Closes #3.

### Dependencies

Usage guide display formatting on the console is achieved via the [command-line-usage](https://www.npmjs.com/package/command-line-usage) package.

Snake casing is achieved now via [lodash](https://lodash.com) package, eliminating the usage of the [casing](https://www.npmjs.com/package/casing) package.